### PR TITLE
linux-raspberrypi: bump to Linux version 5.4.72

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_5.4.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_5.4.bb
@@ -1,7 +1,7 @@
-LINUX_VERSION ?= "5.4.69"
+LINUX_VERSION ?= "5.4.72"
 LINUX_RPI_BRANCH ?= "rpi-5.4.y"
 
-SRCREV_machine = "31d364af258ff9754a1a9c7d8ea532da962797bd"
+SRCREV_machine = "154de7bbd5844a824a635d4f9e3f773c15c6ce11"
 SRCREV_meta = "5d52d9eea95fa09d404053360c2351b2b91b323b"
 
 require linux-raspberrypi_5.4.inc


### PR DESCRIPTION
Fixes: "Bleeding Tooth" Bluetooth Vulnerability.

Signed-off-by: Eino Juhani Oltedal <einoju@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
